### PR TITLE
Add GitHub Pages support for Tic-Tac-Toe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # rag_games
+
+This repository contains simple games. The latest addition is a browser-based Tic-Tac-Toe game.
+
+## Tic-Tac-Toe
+
+The game files now live under `docs/tictactoe` so they can be hosted directly with
+[GitHub Pages](https://docs.github.com/pages/getting-started-with-github-pages).
+If Pages is enabled for this repository with the **docs** folder as the source,
+you can play at:
+
+```
+https://<USER>.github.io/<REPOSITORY>/tictactoe/
+```
+
+Replace `<USER>` and `<REPOSITORY>` with your GitHub username and repository
+name. You can also open `docs/tictactoe/index.html` locally in any browser if
+you prefer to play without Pages.

--- a/docs/tictactoe/index.html
+++ b/docs/tictactoe/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tic-Tac-Toe</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Tic-Tac-Toe</h1>
+    <div id="board" class="board"></div>
+    <div id="message" class="message"></div>
+    <button id="reset">Reset Game</button>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/docs/tictactoe/script.js
+++ b/docs/tictactoe/script.js
@@ -1,0 +1,65 @@
+const board = document.getElementById('board');
+const message = document.getElementById('message');
+const resetBtn = document.getElementById('reset');
+let currentPlayer = 'X';
+let cells = Array(9).fill(null);
+let gameOver = false;
+
+function createBoard() {
+    board.innerHTML = '';
+    cells.forEach((cell, index) => {
+        const div = document.createElement('div');
+        div.classList.add('cell');
+        div.dataset.index = index;
+        div.addEventListener('click', handleMove);
+        div.textContent = cell ? cell : '';
+        board.appendChild(div);
+    });
+    message.textContent = `Player ${currentPlayer}'s turn`;
+}
+
+function handleMove(e) {
+    const index = e.target.dataset.index;
+    if (cells[index] || gameOver) return;
+
+    cells[index] = currentPlayer;
+    e.target.textContent = currentPlayer;
+
+    if (checkWin()) {
+        message.textContent = `Player ${currentPlayer} wins!`;
+        gameOver = true;
+    } else if (cells.every(cell => cell)) {
+        message.textContent = "It's a draw!";
+        gameOver = true;
+    } else {
+        currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
+        message.textContent = `Player ${currentPlayer}'s turn`;
+    }
+}
+
+function checkWin() {
+    const winPatterns = [
+        [0, 1, 2],
+        [3, 4, 5],
+        [6, 7, 8],
+        [0, 3, 6],
+        [1, 4, 7],
+        [2, 5, 8],
+        [0, 4, 8],
+        [2, 4, 6]
+    ];
+
+    return winPatterns.some(pattern => {
+        const [a, b, c] = pattern;
+        return cells[a] && cells[a] === cells[b] && cells[b] === cells[c];
+    });
+}
+
+resetBtn.addEventListener('click', () => {
+    cells = Array(9).fill(null);
+    currentPlayer = 'X';
+    gameOver = false;
+    createBoard();
+});
+
+createBoard();

--- a/docs/tictactoe/style.css
+++ b/docs/tictactoe/style.css
@@ -1,0 +1,36 @@
+body {
+    font-family: Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 40px;
+}
+
+.board {
+    display: grid;
+    grid-template-columns: repeat(3, 100px);
+    grid-template-rows: repeat(3, 100px);
+    gap: 5px;
+    margin-bottom: 20px;
+}
+
+.cell {
+    width: 100px;
+    height: 100px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 2em;
+    border: 1px solid #000;
+    cursor: pointer;
+}
+
+.message {
+    margin-bottom: 20px;
+    font-size: 1.2em;
+}
+
+button {
+    padding: 10px 20px;
+    font-size: 1em;
+}


### PR DESCRIPTION
## Summary
- move Tic-Tac-Toe game into `docs/` so it can be served with GitHub Pages
- document how to enable Pages and play the game online
- include a `.nojekyll` file

## Testing
- `git log -1 --stat`
- `ls docs/tictactoe`

------
https://chatgpt.com/codex/tasks/task_e_684e606ea5408332bbe1d489ad1a467a